### PR TITLE
Allow getting indented properties from objects

### DIFF
--- a/src/components/Tables/TTableSimple.vue
+++ b/src/components/Tables/TTableSimple.vue
@@ -130,7 +130,8 @@
                     :style="`${h.minWidth ? `min-width: ${h.minWidth}` : ''} ${h.width ? `width: ${h.width};` : ''}`"
                 >
                     <slot :name="`column.${h.value}`" v-bind:column="item" v-bind:index="i">
-                        <span v-if="item[h.value] || item[h.value] === 0">{{ h.value.includes('.') ? item[h.value.split('.')[0]][h.value.split('.')[1]] : item[h.value] }}</span>
+                        <span v-if="getValue(item, h.value) != null">{{ getValue(item, h.value) }}</span>
+                        <span v-else-if="h.hasOwnProperty('emptyString')" class="text-gray-400">{{ h.emptyString }}</span>
                         <span v-else-if="emptyCellMessage" class="text-gray-400">{{ emptyCellMessage }}</span>
                     </slot>
                 </td>
@@ -150,6 +151,7 @@ import TProgressBar from "../Elements/TProgressBar.vue";
 import TIcon from "../Elements/TIcon.vue";
 import TMenu from "../Elements/TMenu.vue";
 import TButton from "../Elements/TButton.vue";
+import objectValueGetter from "../../utils/objectValueGetter.js";
 export default {
     name: 'TTableSimple',
     data () {
@@ -322,7 +324,10 @@ export default {
             else this.selectAllOption = this.$refs.rows_to_select.value;
             
             this.$emit('select-control', this.selectAllOption);
-        }
+        },
+        getValue(obj, path, defaultValue = undefined) {
+            return objectValueGetter(obj, path, defaultValue);
+        },
     },
     watch: {
         selection() {

--- a/src/utils/objectValueGetter.js
+++ b/src/utils/objectValueGetter.js
@@ -1,0 +1,12 @@
+const objectValueGetter = (obj, path, defaultValue = undefined) => {
+	const travel = regexp =>
+		String.prototype.split
+			.call(path, regexp)
+			.filter(Boolean)
+			.reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
+	const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+	return result === undefined || result === obj ? defaultValue : result;
+};
+
+// https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_get
+export default objectValueGetter;


### PR DESCRIPTION
This PR allows getting indented properties from objects. After this PR it's possible to get the following property from an object.

```javascript

var obj = {
  a: {
    b: [
      {key: 1},
      {key: 2},
      {key: 3},
    ]
  }
};
```

```javascript
objectValueGetter(obj, 'a.b[1].key'); // return 2
objectValueGetter(obj, 'a.b[10].key'); // return undefined
objectValueGetter(obj, 'a.b[10].key', 'nothing'); // return 'nothing'
```

This PR also provides a placeholder for undefined values per header not per all the items.