### PR TITLE
Custom formatting

### DIFF
--- a/src/components/Tables/TTableSimple.vue
+++ b/src/components/Tables/TTableSimple.vue
@@ -130,7 +130,10 @@
                     :style="`${h.minWidth ? `min-width: ${h.minWidth}` : ''} ${h.width ? `width: ${h.width};` : ''}`"
                 >
                     <slot :name="`column.${h.value}`" v-bind:column="item" v-bind:index="i">
-                        <span v-if="getValue(item, h.value) != null">{{ getValue(item, h.value) }}</span>
+                        <span v-if="getValue(item, h.value) != null">
+                            <span v-if="typeof h.formatValue === 'function'">{{ h.formatValue(getValue(item, h.value)) }}</span>
+                            <span v-else>{{ getValue(item, h.value) }}</span>
+                        </span>
                         <span v-else-if="h.hasOwnProperty('emptyString')" class="text-gray-400">{{ h.emptyString }}</span>
                         <span v-else-if="emptyCellMessage" class="text-gray-400">{{ emptyCellMessage }}</span>
                     </slot>


### PR DESCRIPTION
Before, in order to format a header you could do it only through extending the slot of the column you need which which has 2 downsides:

- requires writing html
- unable to use indented values like `column.order.amount`

This PR allows setting values formatters from the header passed to the `tableSimple` component.

```javascript

const headers = [
    {
        ...,
        formatValue: (v) => v. toUpperCase() // HELLO instead of hello
    },

    {
        ...,
        formatValue: (v) => '$' + v // $110.05 instead of 110.05
    },

]
```